### PR TITLE
Add FRONTEND_URL docs

### DIFF
--- a/backend/.example.env
+++ b/backend/.example.env
@@ -1,2 +1,4 @@
 BLIZZARD_CLIENT_ID=<your-client-id>
 BLIZZARD_CLIENT_SECRET=<your-client-secret>
+
+FRONTEND_URL=<your-frontend-domain>

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,25 @@
+# Backend
+
+This server exposes a small REST API used by the frontend. A few environment
+variables are required for it to run. Copy `.example.env` to `.env` and provide
+real values.
+
+## CORS behaviour
+
+When `NODE_ENV` is set to `production` the server restricts CORS requests to the
+URL defined in the `FRONTEND_URL` environment variable. During development it
+defaults to `http://localhost:3000`.
+
+`FRONTEND_URL` must match the domain where the frontend is deployed, for
+example:
+
+```
+FRONTEND_URL=https://guild-site-iota.vercel.app
+```
+
+## Setting variables in deployments
+
+- **Docker Compose**: add the variable under the `backend` service in
+  `docker-compose.yml` using the `environment:` section.
+- **Railway** or other hosting platforms: define `FRONTEND_URL` in the project
+  environment variables so it is available when the container starts.


### PR DESCRIPTION
## Summary
- add `FRONTEND_URL` placeholder to backend env example
- document how CORS uses `FRONTEND_URL` and how to set it in deployments

## Testing
- `pnpm test` *(fails: no test specified)*